### PR TITLE
Fixed an oversight of mine

### DIFF
--- a/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/durability.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#minecraft:enchantable/armor"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/item/enchantable/equippable.json
+++ b/src/main/resources/data/minecraft/tags/item/enchantable/equippable.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "#minecraft:enchantable/armor"
+  ]
+}


### PR DESCRIPTION
The enchantable/durability and enchantable/equippable inherit from minecraft/x_armor instead of minecraft:enchantble/x_armor,
so I've added that tag to them so you don't have to list each individual armor piece in those two tags