### PR TITLE
Attribute changes and Data fixes

### DIFF
--- a/src/main/java/net/acetheeldritchking/discerning_the_eldritch/items/staffs/DTEStaffTier.java
+++ b/src/main/java/net/acetheeldritchking/discerning_the_eldritch/items/staffs/DTEStaffTier.java
@@ -14,8 +14,8 @@ public class DTEStaffTier implements IronsWeaponTier {
             new AttributeContainer(ASAttributeRegistry.RITUAL_MAGIC_POWER, 0.20f, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(AttributeRegistry.MANA_REGEN, 0.15f, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(AttributeRegistry.COOLDOWN_REDUCTION, 0.25f, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
-            new AttributeContainer(ASAttributeRegistry.MANA_STEAL, 0.25D, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
-            new AttributeContainer(ASAttributeRegistry.MANA_REND, 0.10D, AttributeModifier.Operation.ADD_MULTIPLIED_BASE)
+            new AttributeContainer(ASAttributeRegistry.MANA_STEAL, 1.25, AttributeModifier.Operation.ADD_VALUE),
+            new AttributeContainer(ASAttributeRegistry.MANA_REND, 0.10, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Staff of Ascension

--- a/src/main/java/net/acetheeldritchking/discerning_the_eldritch/items/weapons/DTEWeaponTiers.java
+++ b/src/main/java/net/acetheeldritchking/discerning_the_eldritch/items/weapons/DTEWeaponTiers.java
@@ -45,9 +45,9 @@ public class DTEWeaponTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, 0.20, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(ASAttributeRegistry.RITUAL_MAGIC_POWER, 0.10, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(AttributeRegistry.COOLDOWN_REDUCTION, 0.10, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
-            new AttributeContainer(ASAttributeRegistry.MANA_STEAL, 0.10D, AttributeModifier.Operation.ADD_VALUE),
+            new AttributeContainer(ASAttributeRegistry.MANA_STEAL, 1.10D, AttributeModifier.Operation.ADD_VALUE),
             new AttributeContainer(ASAttributeRegistry.MANA_REND, 0.25D, AttributeModifier.Operation.ADD_VALUE),
-            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.1D, AttributeModifier.Operation.ADD_VALUE)
+            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.75D, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Ritual Dagger
@@ -68,7 +68,7 @@ public class DTEWeaponTiers implements Tier, IronsWeaponTier {
     public static DTEWeaponTiers FORSAKEN_FLAMBERGE = new DTEWeaponTiers(2031, 10F, -2.7F, 6, BlockTags.INCORRECT_FOR_NETHERITE_TOOL, () -> Ingredient.of(ItemRegistry.MITHRIL_INGOT.get()),
             new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, 0.05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(AttributeRegistry.COOLDOWN_REDUCTION, 0.05, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
-            new AttributeContainer(ASAttributeRegistry.MANA_STEAL, 0.05D, AttributeModifier.Operation.ADD_VALUE)
+            new AttributeContainer(ASAttributeRegistry.MANA_STEAL, 1.05D, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Snowgrave
@@ -79,7 +79,7 @@ public class DTEWeaponTiers implements Tier, IronsWeaponTier {
     public static DTEWeaponTiers SOUL_FIRE_SCYTHE = new DTEWeaponTiers(2061, 12F, -2.7F, 15, BlockTags.INCORRECT_FOR_NETHERITE_TOOL, () -> Ingredient.of(ItemRegistry.MITHRIL_INGOT.get()),
             new AttributeContainer(AttributeRegistry.FIRE_SPELL_POWER, 0.15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(AttributeRegistry.FIRE_MAGIC_RESIST, 0.10, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
-            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.05D, AttributeModifier.Operation.ADD_VALUE)
+            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.5, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Cataclysm (Dormant)
@@ -94,7 +94,7 @@ public class DTEWeaponTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, 0.1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(ASAttributeRegistry.RITUAL_MAGIC_POWER, 0.2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(ASAttributeRegistry.GOLIATH_SLAYER, 0.1, AttributeModifier.Operation.ADD_VALUE),
-            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.05, AttributeModifier.Operation.ADD_VALUE)
+            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.5, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Devourer (Dormant)
@@ -109,7 +109,7 @@ public class DTEWeaponTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, 0.1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(ASAttributeRegistry.RITUAL_MAGIC_POWER, 0.2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(ASAttributeRegistry.HUNGER_STEAL, 2, AttributeModifier.Operation.ADD_VALUE),
-            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.05, AttributeModifier.Operation.ADD_VALUE)
+            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.5, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Mourning Star (Dormant)
@@ -124,7 +124,7 @@ public class DTEWeaponTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(AttributeRegistry.ELDRITCH_SPELL_POWER, 0.1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(ASAttributeRegistry.RITUAL_MAGIC_POWER, 0.2, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(ASAttributeRegistry.MANA_REND, 0.1, AttributeModifier.Operation.ADD_VALUE),
-            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.05, AttributeModifier.Operation.ADD_VALUE)
+            new AttributeContainer(ASAttributeRegistry.SPELL_RES_PENETRATION, 0.5, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Starmetal Scythe
@@ -134,18 +134,18 @@ public class DTEWeaponTiers implements Tier, IronsWeaponTier {
             new AttributeContainer(ASAttributeRegistry.MAGIC_PROJECTILE_DAMAGE, 0.10D, AttributeModifier.Operation.ADD_VALUE)
     );
 
-    // Starmetal Scythe
+    // Starmetal Odachi
     public static DTEWeaponTiers STARMETAL_ODACHI = new DTEWeaponTiers(2061, 9.5F, -2.5F, 15, BlockTags.INCORRECT_FOR_NETHERITE_TOOL, () -> Ingredient.of(ItemRegistry.MITHRIL_INGOT.get()),
             new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, 0.10, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(AttributeRegistry.ENDER_MAGIC_RESIST, 0.10, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
-            new AttributeContainer(ASAttributeRegistry.LIFE_RECOVERY, 0.05D, AttributeModifier.Operation.ADD_VALUE)
+            new AttributeContainer(ASAttributeRegistry.DETERMINATION, 0.25, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Void Splitter
     public static DTEWeaponTiers VOIDSPLITTER = new DTEWeaponTiers(2061, 13.5F, -2.5F, 15, BlockTags.INCORRECT_FOR_NETHERITE_TOOL, () -> Ingredient.of(ItemRegistry.MITHRIL_INGOT.get()),
             new AttributeContainer(AttributeRegistry.ENDER_SPELL_POWER, 0.15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE),
             new AttributeContainer(ASAttributeRegistry.MAGIC_DAMAGE_CRIT_CHANCE, 0.15, AttributeModifier.Operation.ADD_VALUE),
-            new AttributeContainer(ASAttributeRegistry.LIFE_RECOVERY, 0.10D, AttributeModifier.Operation.ADD_VALUE)
+            new AttributeContainer(ASAttributeRegistry.DETERMINATION, 0.30, AttributeModifier.Operation.ADD_VALUE)
     );
 
     // Staff of The Spectre

--- a/src/main/resources/assets/discerning_the_eldritch/lang/en_us.json
+++ b/src/main/resources/assets/discerning_the_eldritch/lang/en_us.json
@@ -223,6 +223,7 @@
   "block.discerning_the_eldritch.meteorstone": "Meteorstone",
   "block.discerning_the_eldritch.meteorstone_bricks": "Meteorstone Bricks",
   "block.discerning_the_eldritch.meteorstone_tiles": "Meteorstone Tiles",
+  "block.discerning_the_eldritch.chiseled_meteorstone": "Chiseled Meteorstone",
   "block.discerning_the_eldritch.starstone_ore": "Starstone Ore",
   "block.discerning_the_eldritch.starstone_block": "Block of Starstone",
   "block.discerning_the_eldritch.budding_starstone": "Budding Starstone",
@@ -232,6 +233,7 @@
   "block.discerning_the_eldritch.starstone_cluster": "Starstone Cluster",
   "block.discerning_the_eldritch.resonating_deepslate": "Resonating Deepslate",
   "block.discerning_the_eldritch.vehemite_block": "Block of Vehemite",
+  "block.discerning_the_eldritch.starmetal_block": "Block of Starmetal",
 
   "block.discerning_the_eldritch.polished_starstone_block": "Polished Starstone Block",
 

--- a/src/main/resources/data/discerning_the_eldritch/tags/item/untrimmable_armors.json
+++ b/src/main/resources/data/discerning_the_eldritch/tags/item/untrimmable_armors.json
@@ -1,0 +1,18 @@
+{
+  "values": [
+    "discerning_the_eldritch:crimson_stag_antlers",
+    "discerning_the_eldritch:crimson_stag_robes",
+    "discerning_the_eldritch:crimson_stag_leggings",
+    "discerning_the_eldritch:crimson_stag_boots",
+    "discerning_the_eldritch:eldritch_warlock_hood",
+    "discerning_the_eldritch:eldritch_warlock_mask",
+    "discerning_the_eldritch:eldritch_warlock_helmet",
+    "discerning_the_eldritch:eldritch_warlock_robes",
+    "discerning_the_eldritch:eldritch_warlock_leggings",
+    "discerning_the_eldritch:eldritch_warlock_greaves",
+    "discerning_the_eldritch:starvoid_helmet",
+    "discerning_the_eldritch:starvoid_chestplate",
+    "discerning_the_eldritch:starvoid_leggings",
+    "discerning_the_eldritch:starvoid_greaves"
+  ]
+}

--- a/src/main/resources/data/irons_spellbooks/tags/irons_jewelry/rune.json
+++ b/src/main/resources/data/irons_spellbooks/tags/irons_jewelry/rune.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "discerning_the_eldritch:eldritch_rune"
+  ]
+}

--- a/src/main/resources/data/irons_spellbooks/tags/item/inscribed_rune.json
+++ b/src/main/resources/data/irons_spellbooks/tags/item/inscribed_rune.json
@@ -1,6 +1,6 @@
 {
-  "replace": false,
   "values": [
-    "discerning_the_eldritch:eldritch_rune"
+    "discerning_the_eldritch:eldritch_rune",
+    "discerning_the_eldritch:ritual_rune"
   ]
 }

--- a/src/main/resources/data/irons_spellbooks/tags/item/staff.json
+++ b/src/main/resources/data/irons_spellbooks/tags/item/staff.json
@@ -1,8 +1,8 @@
 {
-  "replace": false,
   "values": [
-    "discerning_the_eldritch:staff_of_eldritch",
+    "discerning_the_eldritch:broken_legends_staff",
     "discerning_the_eldritch:staff_of_ascension",
-    "discerning_the_eldritch:broken_legends_staff"
+    "discerning_the_eldritch:staff_of_eldritch",
+    "discerning_the_eldritch:staff_of_the_spectre"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/item/chest_armor.json
+++ b/src/main/resources/data/minecraft/tags/item/chest_armor.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "discerning_the_eldritch:crimson_stag_robes",
+    "discerning_the_eldritch:eldritch_warlock_robes",
+    "discerning_the_eldritch:starvoid_chestplate"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/item/foot_armor.json
+++ b/src/main/resources/data/minecraft/tags/item/foot_armor.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "discerning_the_eldritch:crimson_stag_boots",
+    "discerning_the_eldritch:eldritch_warlock_greaves",
+    "discerning_the_eldritch:starvoid_greaves"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/item/head_armor.json
+++ b/src/main/resources/data/minecraft/tags/item/head_armor.json
@@ -1,0 +1,9 @@
+{
+  "values": [
+    "discerning_the_eldritch:crimson_stag_antlers",
+    "discerning_the_eldritch:eldritch_warlock_hood",
+    "discerning_the_eldritch:eldritch_warlock_mask",
+    "discerning_the_eldritch:eldritch_warlock_helmet",
+    "discerning_the_eldritch:starvoid_helmet"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/item/leg_armor.json
+++ b/src/main/resources/data/minecraft/tags/item/leg_armor.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "discerning_the_eldritch:crimson_stag_leggings",
+    "discerning_the_eldritch:eldritch_warlock_leggings",
+    "discerning_the_eldritch:starvoid_leggings"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/item/swords.json
+++ b/src/main/resources/data/minecraft/tags/item/swords.json
@@ -1,21 +1,25 @@
 {
-  "replace": false,
   "values": [
-    "discerning_the_eldritch:deep_greatsword",
-    "discerning_the_eldritch:god_spear",
-    "discerning_the_eldritch:ymir",
-    "discerning_the_eldritch:ice_spear",
-    "discerning_the_eldritch:ritual_dagger",
-    "discerning_the_eldritch:forlorn_rapier",
     "discerning_the_eldritch:broken_legends_blade",
-    "discerning_the_eldritch:forsaken_flamberge",
-    "discerning_the_eldritch:snowgrave",
     "discerning_the_eldritch:cataclysm",
-    "discerning_the_eldritch:devourer",
-    "discerning_the_eldritch:mourning_star",
     "discerning_the_eldritch:cataclysm_awakened",
+    "discerning_the_eldritch:deep_greatsword",
+    "discerning_the_eldritch:devourer",
     "discerning_the_eldritch:devourer_awakened",
+    {"id":"discerning_the_eldritch:dream_reaver_ymir","required":false},
+    "discerning_the_eldritch:echo_greatsword",
+    "discerning_the_eldritch:forlorn_rapier",
+    "discerning_the_eldritch:forsaken_flamberge",
+    "discerning_the_eldritch:god_spear",
+    "discerning_the_eldritch:ice_spear",
+    "discerning_the_eldritch:mourning_star",
     "discerning_the_eldritch:mourning_star_awakened",
-    "discerning_the_eldritch:soul_fire_scythe"
+    "discerning_the_eldritch:ritual_dagger",
+    "discerning_the_eldritch:snowgrave",
+    "discerning_the_eldritch:soul_fire_scythe",
+    "discerning_the_eldritch:starmetal_odachi",
+    "discerning_the_eldritch:starmetal_scythe",
+    "discerning_the_eldritch:voidsplitter_scythe",
+    "discerning_the_eldritch:ymir"
   ]
 }

--- a/src/main/resources/data/minecraft/tags/item/trimmable_armor.json
+++ b/src/main/resources/data/minecraft/tags/item/trimmable_armor.json
@@ -1,0 +1,6 @@
+{
+  "values": [],
+  "remove": [
+    "#discerning_the_eldritch:untrimmable_armors"
+  ]
+}


### PR DESCRIPTION
 Staff of Vehemence:
* Changed operations of Mana Steal and Mana Rend to ADD_VALUE
* Changed value of Mana Steal from 0.25 > 1.25 Ymir:
* Changed value of Mana Steal from 0.1 > 1.1
* Changed value of Spell Res Pen from 0.1 > 0.75 Forsaken Flamberge:
* Changed value of Mana Steal from 0.05 > 1.05 Soul Fire Scythe:
* Changed value of Spell Res Pen from 0.05 > 0.5 Awakened weapons:
* Changed value of Spell Res Pen from 0.05 > 0.5 Starmetal Odachi:
* Swapped 0.05 Life Recovery for 0.25 Determination Void Splitter:
* Swapped 0.1 Life Recovery for 0.3 Determination
* Improved armor compatibility by adding them to the base armor tags and removing them from the trimmable armor tag
* Added GnJ 2.0 compatibility
* Made Starvoid armor and weapons enchantable
* Made Void Splitter enchantable
* Made Dream Reaver Ymir enchantable Added lang for Chiseled Meteorstone and Block of Starmetal